### PR TITLE
Fixed path to produced WEM file.

### DIFF
--- a/wav2wem
+++ b/wav2wem
@@ -6,7 +6,10 @@
 # Usage:
 #     wav2wem FILE...
 #
-SCRIPTPATH=$(readlink -f "$0")
+SCRIPTPATH=$0
+if [ $(uname) != "Darwin" ]; then
+    SCRIPTPATH=$(readlink -f "$0")
+fi
 THISPATH=$(cd "$(dirname "$SCRIPTPATH")"; pwd)
 
 for var in "$@"


### PR DESCRIPTION
I don't know why you had it that way, I've never seen converted files in there.

I also needed upgrade to 2013.2.4 (which is bigger), `mfc90u.dll` and probably `winetricks directx9`.
